### PR TITLE
Fix build steps attribute names

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -2,7 +2,7 @@
 version: '1.0'
 
 steps:
-  init-variables:
+  init_variables:
     title: Init variables
     image: alpine
     commands:
@@ -14,7 +14,7 @@ steps:
     title: Build image
     type: build
     description: Build catalogue
-    image-name: cloudpossedemo/catalogue
+    image_name: cloudpossedemo/catalogue
     dockerfile: Dockerfile
 
   semver:


### PR DESCRIPTION
## what
* Fix build steps attribute names

## why
* Using `-` in attribute names is obsolete
* The names should include only letters, digits and underscores
